### PR TITLE
Dependencies and logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sympy
+transitions
+numpy

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ __version__ = _temp.__version__
 setup(
     name=f"{agent_package}agent",
     version=__version__,
-    install_requires=["volttron", "sympy", "transitions", "numpy"],
     packages=packages,
     package_dir={'': 'src'},
     entry_points={"setuptools.installation": [f"eggsecutable = {agent_module}:main"]},
@@ -40,7 +39,7 @@ setup(
         "Topic :: Home Automation",
         "Topic :: Software Development :: Embedded Systems",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/src/ilc/control_handler.py
+++ b/src/ilc/control_handler.py
@@ -29,7 +29,6 @@ import gevent
 from importlib.metadata import distribution, PackageNotFoundError
 try:
     distribution('volttron-core')
-    from volttron.client.logs import setup_logging
     from volttron.client.messaging import headers as headers_mod
     from volttron.client.vip.agent import Agent
     from volttron.utils import format_timestamp, get_aware_utc_now
@@ -37,12 +36,11 @@ try:
 except PackageNotFoundError:
     from volttron.platform.vip.agent import Agent
     from volttron.platform.messaging import headers as headers_mod
-    from volttron.platform.agent.utils import format_timestamp, get_aware_utc_now, setup_logging
+    from volttron.platform.agent.utils import format_timestamp, get_aware_utc_now
     from volttron.platform.jsonrpc import RemoteError
 
 from ilc.utils import parse_sympy, sympy_evaluate, create_device_topic_map, fix_up_point_name
 
-setup_logging()
 _log = logging.getLogger(__name__)
 
 

--- a/src/ilc/criteria_handler.py
+++ b/src/ilc/criteria_handler.py
@@ -32,17 +32,15 @@ from sympy.core import numbers
 from importlib.metadata import distribution, PackageNotFoundError
 try:
     distribution('volttron-core')
-    from volttron.client.logs import setup_logging
     from volttron.client.messaging import headers as headers_mod
     from volttron.utils import get_aware_utc_now, format_timestamp
 except PackageNotFoundError:
     from volttron.platform.messaging import headers as headers_mod
-    from volttron.platform.agent.utils import format_timestamp, get_aware_utc_now, setup_logging
+    from volttron.platform.agent.utils import format_timestamp, get_aware_utc_now
 
 from ilc.ilc_matrices import (build_score, input_matrix)
 from ilc.utils import sympy_evaluate, create_device_topic_map, fix_up_point_name
 
-setup_logging()
 _log = logging.getLogger(__name__)
 
 criterion_registry = {}

--- a/src/ilc/ilc_matrices.py
+++ b/src/ilc/ilc_matrices.py
@@ -29,18 +29,7 @@ import operator
 from collections import defaultdict
 from functools import reduce
 
-from importlib.metadata import distribution, PackageNotFoundError
-try:
-    distribution('volttron-core')
-    from volttron.client.logs import setup_logging
-except PackageNotFoundError:
-    from volttron.platform.agent.utils import setup_logging
-
-setup_logging()
 _log = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s   %(levelname)-8s %(message)s',
-                    datefmt='%m-%d-%y %H:%M:%S')
 
 
 def extract_criteria(filename):


### PR DESCRIPTION
This pull request primarily removes redundant logging setup code (`setup_logging()`) from several modules and updates the supported Python versions in `setup.py`. These changes streamline the codebase by relying on standard logging initialization and clarify Python compatibility.

**Logging setup removal:**

* Removed calls to `setup_logging()` and related import statements from `src/ilc/control_handler.py`, `src/ilc/criteria_handler.py`, and `src/ilc/ilc_matrices.py`, relying instead on standard logging practices. [[1]](diffhunk://#diff-b870ccf9d0480edf5e571e4dc72781e09321882854854855a395359443f97d1aL32-L45) [[2]](diffhunk://#diff-ecb1162915f84350ad2b578ddb899764f2e41e73f2881ea9f7bfe7b304e14492L35-L45) [[3]](diffhunk://#diff-3a622a019ae4aeffdefce865f1c33a5bf1170d317e5da79cfbd09aaef06fda38L32-L43)
* Cleaned up custom logging configuration in `src/ilc/ilc_matrices.py`.

**Python version and packaging updates:**

* Updated `setup.py` to remove Python 3.8 support and add Python 3.10 support in the classifiers.
* Removed the `install_requires` line from `setup.py` to defer to VOLTTRON's handling of dependencies from requirements.txt.